### PR TITLE
Fix broken link to pkgdown site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tidytemplate
 
-tidytemplate provides a custom [pkgdown](http://hadley.github.io/pkgdown/) template for core tidyverse packages (i.e. packages hosted by the [tidyverse organisation](http://github.com/tidyverse)). Please don't use it for your own package.
+tidytemplate provides a custom [pkgdown](http://pkgdown.r-lib.org) template for core tidyverse packages (i.e. packages hosted by the [tidyverse organisation](http://github.com/tidyverse)). Please don't use it for your own package.
 
 The theme is built on top of the [paper bootswatch theme](https://bootswatch.com/paper/).
 

--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -4,7 +4,7 @@
 
 <div class="author">
   <p>Developed by {{#package}}{{{authors}}}{{/package}}.</p>
-  <p>Site built by <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built by <a href="http://pkgdown.r-lib.org">pkgdown</a>.</p>
 </div>
 
 <script>


### PR DESCRIPTION
http://hadley.github.io/pkgdown/ gives a 404 error so I've updated it to http://pkgdown.r-lib.org in the footer template and the README.