### PR TITLE
add css for orcid img

### DIFF
--- a/inst/pkgdown/assets/pkgdown.css
+++ b/inst/pkgdown/assets/pkgdown.css
@@ -234,3 +234,10 @@ a.anchor {
   background-color: transparent;
   text-decoration: underline;
 }
+
+/* orcid ------------------------------------ */
+
+.orcid {
+  height: 16px;
+  vertical-align: middle;
+}


### PR DESCRIPTION
to fix huge orcid imgs on tidyverse pages.

http://dplyr.tidyverse.org/