### PR TITLE
Fix navbar classes ⇨ small class stays small.

### DIFF
--- a/inst/pkgdown/templates/navbar.html
+++ b/inst/pkgdown/templates/navbar.html
@@ -8,8 +8,8 @@
         <span class="icon-bar"></span>
       </button>
 
-      <div class="navbar-brand">
-        <a class="navbar-link" href="{{#site}}{{root}}{{/site}}index.html">{{#package}}{{name}}{{/package}}</a>
+      <div class="navbar-brand-container">
+        <a class="navbar-brand" href="{{#site}}{{root}}{{/site}}index.html">{{#package}}{{name}}{{/package}}</a>
         <small class="tidyverse">part of the <a href="http://tidyverse.org">tidyverse</a></small>
       </div>
     </div>


### PR DESCRIPTION
* Fixes #15.
* Changed so div class = `navbar-brand-container`; main link class = `navbar-brand`.
* Means `<small>` element is in `navbar-brand-container` and sizes correctly.