### PR TITLE
Mention .travis.yml changes needed if auto-deploying to github pages

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -48,6 +48,15 @@ template:
     footer: ...
 ```
 
+If you deploy to github pages automatically using travis, add the following
+to your `.travis.yml`:
+
+```yaml
+r_github_packages:
+  - tidyverse/tidytemplate
+```
+
+
 ## CSS files
 
 Threee CSS files play a role in styling the site:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ template:
     footer: ...
 ```
 
+If you deploy to github pages automatically using travis, add the
+following to your `.travis.yml`:
+
+``` yaml
+r_github_packages:
+  - tidyverse/tidytemplate
+```
+
 ## CSS files
 
 Threee CSS files play a role in styling the site:


### PR DESCRIPTION
Testing out `pkgdown::deploy_site_github()` with `yardstick` and noticed that to deploy with the `tidytemplate` theme, you'll have to adjust `.travis.yml` to install `tidytemplate` from github.

PS) Pretty sure it makes sense to adjust `.travis.yml` and not add to `Remotes:` because we don't want `tidytemplate` in `Suggests:`.