### PR TITLE
correctly apply css on h4 header for code transparent background

### DIFF
--- a/inst/pkgdown/BS5/extra.scss
+++ b/inst/pkgdown/BS5/extra.scss
@@ -229,7 +229,7 @@ pre {
   font-size: 0.81em;
 }
 
-h1 code, h2 code, h3 code, h3 code, h5 code, h6 code {
+h1 code, h2 code, h3 code, h4 code, h5 code, h6 code {
   background: transparent;
   padding: 0;
 }


### PR DESCRIPTION
This follows changes in https://github.com/tidyverse/tidytemplate/commit/5b7ed554a9f1c5423dce626d46aaaf883a146b94 where h4 header was missed in the process