### PR TITLE
Fix yaml in Posit logo html

### DIFF
--- a/inst/pkgdown/BS5/_pkgdown.yml
+++ b/inst/pkgdown/BS5/_pkgdown.yml
@@ -23,10 +23,11 @@ authors:
     href: https://www.rstudio.com
     html: <img src='https://www.tidyverse.org/rstudio-logo.svg' alt='RStudio' width='72' />
   Posit, PBC:
-    href: https://www.posit.io
-    html: '<img src="https://www.tidyverse.org/posit-logo.svg" alt="Posit" height="16" style="margin-bottom: 3px;" />'
+    href: https://www.posit.co
+    html: >-
+      <img src='https://www.tidyverse.org/posit-logo.svg' alt='Posit' height='16' style="margin-bottom: 3px;" />
   Posit Software, PBC:
-    href: https://www.posit.io
+    href: https://www.posit.co
     html: >-
       <img src='https://www.tidyverse.org/posit-logo.svg' alt='Posit' height='16' style="margin-bottom: 3px;" />
 

--- a/inst/pkgdown/BS5/_pkgdown.yml
+++ b/inst/pkgdown/BS5/_pkgdown.yml
@@ -24,10 +24,10 @@ authors:
     html: <img src='https://www.tidyverse.org/rstudio-logo.svg' alt='RStudio' width='72' />
   Posit, PBC:
     href: https://www.posit.io
-    html: <img src='https://www.tidyverse.org/posit-logo.svg' alt='Posit' height='16' style="margin-bottom: 3px;" />
+    html: <img src='https://www.tidyverse.org/posit-logo.svg' alt='Posit' height='16' style="margin-bottom:3px;" />
   Posit Software, PBC:
     href: https://www.posit.io
-    html: <img src='https://www.tidyverse.org/posit-logo.svg' alt='Posit' height='16' style="margin-bottom: 3px;" />
+    html: <img src='https://www.tidyverse.org/posit-logo.svg' alt='Posit' height='16' style="margin-bottom:3px;" />
 
   Alison Hill:
     href: https://www.apreshill.com

--- a/inst/pkgdown/BS5/_pkgdown.yml
+++ b/inst/pkgdown/BS5/_pkgdown.yml
@@ -24,10 +24,11 @@ authors:
     html: <img src='https://www.tidyverse.org/rstudio-logo.svg' alt='RStudio' width='72' />
   Posit, PBC:
     href: https://www.posit.io
-    html: <img src='https://www.tidyverse.org/posit-logo.svg' alt='Posit' height='16' style="margin-bottom:3px;" />
+    html: '<img src="https://www.tidyverse.org/posit-logo.svg" alt="Posit" height="16" style="margin-bottom: 3px;" />'
   Posit Software, PBC:
     href: https://www.posit.io
-    html: <img src='https://www.tidyverse.org/posit-logo.svg' alt='Posit' height='16' style="margin-bottom:3px;" />
+    html: >-
+      <img src='https://www.tidyverse.org/posit-logo.svg' alt='Posit' height='16' style="margin-bottom: 3px;" />
 
   Alison Hill:
     href: https://www.apreshill.com


### PR DESCRIPTION
Apparently YAML doesn't like the `: ` in the `html` string.

This shows up in CI runs using tidytemplate

```
Error in yaml.load(readLines(con, warn = readLines.warn), error.label = error.label,  : 
  (/home/runner/work/_temp/Library/tidytemplate/pkgdown/BS5/_pkgdown.yml) Scanner error: mapping values are not allowed in this context at line [27](https://github.com/rstudio/academyMilestones/actions/runs/4065020062/jobs/6999166648#step:12:28), column 107
Calls: <Anonymous> ... find_template_config -> %||% -> <Anonymous> -> yaml.load
```