### PR TITLE
Fix width on Firefox macOS

### DIFF
--- a/inst/pkgdown/BS5/_pkgdown.yml
+++ b/inst/pkgdown/BS5/_pkgdown.yml
@@ -12,7 +12,7 @@ template:
     pkgdown-nav-height: 78px
 
 code:
-  width: 74
+  width: 71
 
 navbar:
   type: light


### PR DESCRIPTION
Closes #84.

With the current width:

![image](https://github.com/user-attachments/assets/2b87e085-1257-48a2-a4e8-a3562f799a9b)

A previous version of the README in duckplyr with width = 72 still had a scrollbar:

![image](https://github.com/user-attachments/assets/60c9c85f-3429-4b2a-adf8-4baa98d41704)

A width of 71 seems safe. Maybe go with 70 to be very sure?