### PR TITLE
Add Garrick's link to authors in tidytemplate

### DIFF
--- a/inst/pkgdown/BS5/_pkgdown.yml
+++ b/inst/pkgdown/BS5/_pkgdown.yml
@@ -43,6 +43,8 @@ authors:
     href: https://github.com/DavisVaughan
   Gábor Csárdi:
     href: https://github.com/gaborcsardi
+  Garrick Aden-Buie:
+    href: https://garrickadenbuie.com
   Hadley Wickham:
     href: https://hadley.nz
   Hannah Frick:


### PR DESCRIPTION
The Shiny team uses the tidytemplate in a few places, it'd be helpful to be included here to avoid having to update a few different sites.